### PR TITLE
Updated Clearance Remember_me to use global cookies

### DIFF
--- a/lib/clearance/authentication.rb
+++ b/lib/clearance/authentication.rb
@@ -48,7 +48,8 @@ module Clearance
       if user
         cookies[:remember_token] = {
           :value   => user.remember_token,
-          :expires => Clearance.configuration.cookie_expiration.call
+          :expires => Clearance.configuration.cookie_expiration.call,
+          :domain  => :all
         }
         self.current_user = user
       end


### PR DESCRIPTION
This is a fix for the help users as a result of the cookie change on the labs platform.
